### PR TITLE
[AuthenticationEntryPoint] AuthenticationEntryPoint 이해

### DIFF
--- a/src/main/java/com/example/springsecurityoauth2/SecurityConfig.java
+++ b/src/main/java/com/example/springsecurityoauth2/SecurityConfig.java
@@ -1,33 +1,35 @@
 package com.example.springsecurityoauth2;
 
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
 
-  // 싱글톤 아니니까 2개가 생성되는걸 확인
+  // formLogin(), httpBasic() 같이 해도 authenticationEntryPoint가 가장 우선순위임
+  // formLogin(), httpBasic() 여기선 form 인증 방식의 요청이 우선순위임
   @Bean
-  public SecurityFilterChain securityFilterChain1(HttpSecurity http) throws Exception {
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.authorizeRequests(request -> request
             .anyRequest()
             .authenticated())
         .formLogin();
-//        .apply(new CustomSecurityConfigurer().setFlag(false));
-
-    return http.build();
-  }
-
-  @Bean
-  public SecurityFilterChain securityFilterChain2(HttpSecurity http) throws Exception {
-    http.authorizeRequests(request -> request
-            .anyRequest()
-            .authenticated())
-//        .formLogin()
-        .httpBasic();
-
+//        .httpBasic()
+//    http.exceptionHandling().authenticationEntryPoint(new AuthenticationEntryPoint() {
+//      @Override
+//      public void commence(HttpServletRequest request, HttpServletResponse response,
+//          AuthenticationException authException) throws IOException, ServletException {
+//        System.out.println("custom EntryPoint");
+//      }
+//    });
     return http.build();
   }
 


### PR DESCRIPTION
AuthenticationEntryPoint는 Custom 생성시 가장 우선이 된다.
- httpBasic(), formLogin(), authenticationEntryPoiny() 인증 방식을 동시에 실행시켰을 때 가장 우선인 것을 확인함
- httpBasic(), formLogin() 인증 방식을 동시에 실행시켰을 때 formLogin()이 작동하는 것을 확인함